### PR TITLE
Add player rating models

### DIFF
--- a/app/models/historical_player_rating.rb
+++ b/app/models/historical_player_rating.rb
@@ -1,0 +1,15 @@
+# == Schema Information
+#
+# Table name: historical_player_ratings
+#
+#  id                                                 :bigint           not null, primary key
+#  elo(trueskill mu normalized between 1000 and 2000) :integer
+#  mu(trueskill mu)                                   :decimal(, )
+#  player_name(historical player name)                :string
+#  sigma(trueskill sigma)                             :decimal(, )
+#  created_at                                         :datetime         not null
+#  updated_at                                         :datetime         not null
+#
+class HistoricalPlayerRating < ApplicationRecord
+
+end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -32,9 +32,10 @@ class Player < ApplicationRecord
     player
   end
 
-  has_many :companies
+  has_many :companies, inverse_of: :player
   has_many :doctrines, through: :companies
   has_many :factions, through: :companies
+  has_one :player_rating, inverse_of: :player
 
   def entity
     Entity.new(self)

--- a/app/models/player_rating.rb
+++ b/app/models/player_rating.rb
@@ -1,0 +1,23 @@
+# == Schema Information
+#
+# Table name: player_ratings
+#
+#  id                                                 :bigint           not null, primary key
+#  elo(trueskill mu normalized between 1000 and 2000) :integer
+#  mu(trueskill mu)                                   :decimal(, )
+#  sigma(trueskill sigma)                             :decimal(, )
+#  created_at                                         :datetime         not null
+#  updated_at                                         :datetime         not null
+#  player_id                                          :bigint
+#
+# Indexes
+#
+#  index_player_ratings_on_player_id  (player_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (player_id => players.id)
+#
+class PlayerRating < ApplicationRecord
+  belongs_to :player, inverse_of: :player_rating
+end

--- a/db/migrate/20231201053808_create_historical_player_ratings.rb
+++ b/db/migrate/20231201053808_create_historical_player_ratings.rb
@@ -1,0 +1,12 @@
+class CreateHistoricalPlayerRatings < ActiveRecord::Migration[6.1]
+  def change
+    create_table :historical_player_ratings, comment: "" do |t|
+      t.string :player_name, comment: "historical player name"
+      t.integer :elo, comment: "trueskill mu normalized between 1000 and 2000"
+      t.decimal :mu, comment: "trueskill mu"
+      t.decimal :sigma, comment: "trueskill sigma"
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231201053817_create_player_ratings.rb
+++ b/db/migrate/20231201053817_create_player_ratings.rb
@@ -1,0 +1,12 @@
+class CreatePlayerRatings < ActiveRecord::Migration[6.1]
+  def change
+    create_table :player_ratings do |t|
+      t.references :player, index: true, foreign_key: true
+      t.integer :elo, comment: "trueskill mu normalized between 1000 and 2000"
+      t.decimal :mu, comment: "trueskill mu"
+      t.decimal :sigma, comment: "trueskill sigma"
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_15_015147) do
+ActiveRecord::Schema.define(version: 2023_12_01_053817) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -258,6 +258,15 @@ ActiveRecord::Schema.define(version: 2023_05_15_015147) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "historical_player_ratings", force: :cascade do |t|
+    t.string "player_name", comment: "historical player name"
+    t.integer "elo", comment: "trueskill mu normalized between 1000 and 2000"
+    t.decimal "mu", comment: "trueskill mu"
+    t.decimal "sigma", comment: "trueskill sigma"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "offmaps", force: :cascade do |t|
     t.string "name", null: false, comment: "Offmap name"
     t.string "display_name", null: false, comment: "Offmap display name"
@@ -274,6 +283,16 @@ ActiveRecord::Schema.define(version: 2023_05_15_015147) do
     t.integer "shells_fired", comment: "Number of shells fired during the offmap"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "player_ratings", force: :cascade do |t|
+    t.bigint "player_id"
+    t.integer "elo", comment: "trueskill mu normalized between 1000 and 2000"
+    t.decimal "mu", comment: "trueskill mu"
+    t.decimal "sigma", comment: "trueskill sigma"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["player_id"], name: "index_player_ratings_on_player_id"
   end
 
   create_table "players", comment: "Player record", force: :cascade do |t|
@@ -589,6 +608,7 @@ ActiveRecord::Schema.define(version: 2023_05_15_015147) do
   add_foreign_key "doctrine_unlocks", "doctrines"
   add_foreign_key "doctrine_unlocks", "unlocks"
   add_foreign_key "doctrines", "factions"
+  add_foreign_key "player_ratings", "players"
   add_foreign_key "restriction_callin_modifiers", "callin_modifiers"
   add_foreign_key "restriction_callin_modifiers", "restrictions"
   add_foreign_key "restriction_callin_modifiers", "rulesets"

--- a/spec/factories/historical_player_rating.rb
+++ b/spec/factories/historical_player_rating.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :historical_player_rating do
+    sequence :player_name do |n| "Player #{n}" end
+    elo { 1500 }
+    mu { 25.0 }
+    sigma { 8.33333 }
+  end
+end

--- a/spec/factories/player_rating.rb
+++ b/spec/factories/player_rating.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :player_rating do
+    association :player
+    elo { 1500 }
+    mu { 25.0 }
+    sigma { 8.33333 }
+  end
+end

--- a/spec/models/historical_player_rating.rb
+++ b/spec/models/historical_player_rating.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe HistoricalPlayerRating, type: :model do
+
+end

--- a/spec/models/player_rating.rb
+++ b/spec/models/player_rating.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe PlayerRating, type: :model do
+  let!(:player_rating) { create :player_rating}
+
+  describe 'associations' do
+    it { should belong_to(:player) }
+  end
+end

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe Player, type: :model do
     it { should have_many(:companies) }
     it { should have_many(:factions) }
     it { should have_many(:doctrines) }
+    it { should have_one(:player_rating) }
   end
 end
-
-


### PR DESCRIPTION
Models for 
`historical player rating` - historical player rating calculated from various scripts, representing player skill from before the inception of this website. Meant to be associated with a player by name
`player rating` - associated with a `player`, meant to be kept update to date and used for match balancing