### PR TITLE
Battle player assignment

### DIFF
--- a/app/models/battle.rb
+++ b/app/models/battle.rb
@@ -2,14 +2,15 @@
 #
 # Table name: battles
 #
-#  id                         :bigint           not null, primary key
-#  name(Optional battle name) :string
-#  size(Size of each team)    :integer          not null
-#  state(Battle status)       :string           not null
-#  winner(Winning side)       :string
-#  created_at                 :datetime         not null
-#  updated_at                 :datetime         not null
-#  ruleset_id                 :bigint           not null
+#  id                                                                   :bigint           not null, primary key
+#  elo_diff(Elo difference between most balanced teams, absolute value) :integer
+#  name(Optional battle name)                                           :string
+#  size(Size of each team)                                              :integer          not null
+#  state(Battle status)                                                 :string           not null
+#  winner(Winning side)                                                 :string
+#  created_at                                                           :datetime         not null
+#  updated_at                                                           :datetime         not null
+#  ruleset_id                                                           :bigint           not null
 #
 # Indexes
 #
@@ -102,15 +103,6 @@ class Battle < ApplicationRecord
     battle_players.filter { |bp| bp.side == BattlePlayer::sides[:axis] }
   end
 
-  # Positive is allied favored, negative is axis favored
-  def elo_difference
-    if players_full?
-      Ratings::BattleRatingsService.new(self).get_elo_difference
-    else
-      nil
-    end
-  end
-
   def entity
     Entity.new(self)
   end
@@ -124,6 +116,6 @@ class Battle < ApplicationRecord
     expose :winner
 
     expose :battle_players, as: :battlePlayers, using: BattlePlayer::Entity, if: { type: :include_players }
-    expose :elo_difference, as: :eloDifference, if: { type: :include_players }
+    expose :elo_diff, as: :eloDifference, if: { type: :include_players }
   end
 end

--- a/app/models/battle_player.rb
+++ b/app/models/battle_player.rb
@@ -2,14 +2,16 @@
 #
 # Table name: battle_players
 #
-#  id                                    :bigint           not null, primary key
-#  abandoned(Is this player abandoning?) :boolean
-#  side(Team side)                       :string           not null
-#  created_at                            :datetime         not null
-#  updated_at                            :datetime         not null
-#  battle_id                             :bigint           not null
-#  company_id                            :bigint           not null
-#  player_id                             :bigint           not null
+#  id                                      :bigint           not null, primary key
+#  abandoned(Is this player abandoning?)   :boolean          default(FALSE)
+#  ready(Ready flag for the player)        :boolean          default(FALSE)
+#  side(Team side)                         :string           not null
+#  team_balance(Assigned team for balance) :integer
+#  created_at                              :datetime         not null
+#  updated_at                              :datetime         not null
+#  battle_id                               :bigint           not null
+#  company_id                              :bigint           not null
+#  player_id                               :bigint           not null
 #
 # Indexes
 #
@@ -55,5 +57,6 @@ class BattlePlayer < ApplicationRecord
     expose :abandoned
     expose :company_doctrine, as: :companyDoctrine
     expose :ready
+    expose :team_balance, as: :teamBalance
   end
 end

--- a/app/models/battle_player.rb
+++ b/app/models/battle_player.rb
@@ -43,6 +43,11 @@ class BattlePlayer < ApplicationRecord
     company.doctrine.name
   end
 
+  # TODO Are we sure we want to surface this?
+  def player_elo
+    player.player_rating.elo
+  end
+
   def entity
     Entity.new(self)
   end

--- a/app/services/battle_service.rb
+++ b/app/services/battle_service.rb
@@ -76,6 +76,7 @@ class BattleService
       if battle.reload.players_full?
         battle.full!
         type = PLAYER_JOINED_FULL
+        Ratings::BattleRatingsService.new(battle).find_most_balanced_teams
       else
         type = PLAYER_JOINED
       end

--- a/app/services/ratings/battle_ratings_service.rb
+++ b/app/services/ratings/battle_ratings_service.rb
@@ -36,6 +36,12 @@ module Ratings
       [lowest_elo_diff, sort_battle_players(lowest_elo_diff_team1), sort_battle_players(lowest_elo_diff_team2)]
     end
 
+    def clear_battle_balance_data
+      @battle.update!(elo_diff: nil)
+      bps = @battle.battle_players.each { |bp| bp.team_balance = nil }.to_a
+      BattlePlayer.import! bps, on_duplicate_key_update: { conflict_target: [:id], columns: [:team_balance] }
+    end
+
     private
 
     def average_elo(battle_players)

--- a/app/services/ratings/battle_ratings_service.rb
+++ b/app/services/ratings/battle_ratings_service.rb
@@ -5,11 +5,12 @@ module Ratings
       @battle = battle
     end
 
+    # TODO is there a use anymore for this?
     def get_elo_difference
       calculate_elo_difference(@battle.allied_battle_players, @battle.axis_battle_players)
     end
 
-    def find_most_balanced_teams
+    def find_most_balanced_teams(persist = true)
       # for battle players
       # try all permutations of the elements split in two teams
       team_size = @battle.size
@@ -19,8 +20,8 @@ module Ratings
       lowest_elo_diff_team1 = nil
       lowest_elo_diff_team2 = nil
       @battle.battle_players.to_a.permutation do |p|
-        team1 = p[0,team_size]
-        team2 = p[team_size,total_size]
+        team1 = p[0, team_size]
+        team2 = p[team_size, total_size]
 
         abs_elo_diff = calc_absolute_elo_difference(team1, team2)
         if abs_elo_diff < lowest_elo_diff
@@ -29,6 +30,8 @@ module Ratings
           lowest_elo_diff_team2 = team2
         end
       end
+
+      persist_balance_updates(lowest_elo_diff, lowest_elo_diff_team1, lowest_elo_diff_team2) if persist
 
       [lowest_elo_diff, sort_battle_players(lowest_elo_diff_team1), sort_battle_players(lowest_elo_diff_team2)]
     end
@@ -56,6 +59,19 @@ module Ratings
 
     def sort_battle_players(battle_players)
       battle_players.sort_by { |bp| bp.player.name }
+    end
+
+    def persist_balance_updates(elo_diff, battle_players_team1, battle_players_team2)
+      ActiveRecord::Base.transaction do
+        @battle.update!(elo_diff: elo_diff)
+        persist_battle_player_team(battle_players_team1, 1)
+        persist_battle_player_team(battle_players_team2, 2)
+      end
+    end
+
+    def persist_battle_player_team(battle_players, team)
+      battle_players.each { |bp| bp.team_balance = team }
+      BattlePlayer.import! battle_players.to_a, on_duplicate_key_update: { conflict_target: [:id], columns: [:team_balance] }
     end
   end
 end

--- a/db/migrate/20231207041959_add_elo_diff_to_battles.rb
+++ b/db/migrate/20231207041959_add_elo_diff_to_battles.rb
@@ -1,0 +1,5 @@
+class AddEloDiffToBattles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :battles, :elo_diff, :integer, comment: "Elo difference between most balanced teams, absolute value"
+  end
+end

--- a/db/migrate/20231207042011_add_team_assignment_to_battle_players.rb
+++ b/db/migrate/20231207042011_add_team_assignment_to_battle_players.rb
@@ -1,0 +1,5 @@
+class AddTeamAssignmentToBattlePlayers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :battle_players, :team_balance, :integer, comment: "Assigned team for balance"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_12_01_053817) do
+ActiveRecord::Schema.define(version: 2023_12_07_042011) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -105,11 +105,11 @@ ActiveRecord::Schema.define(version: 2023_12_01_053817) do
     t.boolean "abandoned", default: false, comment: "Is this player abandoning?"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "team_balance", comment: "Assigned team for balance"
     t.index ["battle_id"], name: "index_battle_players_on_battle_id"
     t.index ["company_id"], name: "index_battle_players_on_company_id"
     t.index ["player_id"], name: "index_battle_players_on_player_id"
   end
-
 
   create_table "battles", force: :cascade do |t|
     t.string "name", comment: "Optional battle name"
@@ -119,6 +119,7 @@ ActiveRecord::Schema.define(version: 2023_12_01_053817) do
     t.bigint "ruleset_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "elo_diff", comment: "Elo difference between most balanced teams, absolute value"
     t.index ["ruleset_id"], name: "index_battles_on_ruleset_id"
     t.index ["state"], name: "index_battles_on_state"
   end

--- a/spec/services/ratings/battle_ratings_service_spec.rb
+++ b/spec/services/ratings/battle_ratings_service_spec.rb
@@ -234,4 +234,24 @@ RSpec.describe Ratings::BattleRatingsService do
     end
   end
 
+  describe "#clear_battle_balance_data" do
+    let!(:battle) { create :battle, elo_diff: 100 }
+    let!(:bp1) { create :battle_player, battle: battle, player: player1, team_balance: 1 }
+    let!(:bp2) { create :battle_player, battle: battle, player: player2, team_balance: 2 }
+    let!(:bp3) { create :battle_player, :axis, battle: battle, player: player3, team_balance: 1 }
+
+    subject { described_class.new(battle).clear_battle_balance_data }
+
+    it "clears battle elo_diff" do
+      subject
+      expect(battle.reload.elo_diff).to be nil
+    end
+
+    it "clears battle players team_balance" do
+      subject
+      expect(bp1.reload.team_balance).to be nil
+      expect(bp2.reload.team_balance).to be nil
+      expect(bp3.reload.team_balance).to be nil
+    end
+  end
 end

--- a/spec/services/ratings/battle_ratings_service_spec.rb
+++ b/spec/services/ratings/battle_ratings_service_spec.rb
@@ -117,6 +117,16 @@ RSpec.describe Ratings::BattleRatingsService do
           expect(team1).to match_array [bp1, bp3]
           expect(team2).to match_array [bp2, bp4]
         end
+
+        it "persists the results" do
+          subject
+
+          expect(battle.reload.elo_diff).to eq 0
+          expect(bp1.reload.team_balance).to eq 1
+          expect(bp2.reload.team_balance).to eq 2
+          expect(bp3.reload.team_balance).to eq 1
+          expect(bp4.reload.team_balance).to eq 2
+        end
       end
 
       context "when there is non-zero elo diff" do
@@ -131,6 +141,16 @@ RSpec.describe Ratings::BattleRatingsService do
           expect(elo_diff).to eq 200
           expect(team1).to match_array [bp1, bp2]
           expect(team2).to match_array [bp3, bp4]
+        end
+
+        it "persists the results" do
+          subject
+
+          expect(battle.reload.elo_diff).to eq 200
+          expect(bp1.reload.team_balance).to eq 1
+          expect(bp2.reload.team_balance).to eq 1
+          expect(bp3.reload.team_balance).to eq 2
+          expect(bp4.reload.team_balance).to eq 2
         end
       end
     end
@@ -163,6 +183,20 @@ RSpec.describe Ratings::BattleRatingsService do
           expect(team1).to match_array [bp1, bp3, bp5, bp7]
           expect(team2).to match_array [bp2, bp4, bp6, bp8]
         end
+
+        it "persists the results" do
+          subject
+
+          expect(battle.reload.elo_diff).to eq 0
+          expect(bp1.reload.team_balance).to eq 1
+          expect(bp2.reload.team_balance).to eq 2
+          expect(bp3.reload.team_balance).to eq 1
+          expect(bp4.reload.team_balance).to eq 2
+          expect(bp5.reload.team_balance).to eq 1
+          expect(bp6.reload.team_balance).to eq 2
+          expect(bp7.reload.team_balance).to eq 1
+          expect(bp8.reload.team_balance).to eq 2
+        end
       end
 
       context "when there is non-zero elo diff" do
@@ -181,6 +215,20 @@ RSpec.describe Ratings::BattleRatingsService do
           expect(elo_diff).to eq 9
           expect(team1).to match_array [bp1, bp2, bp6, bp8]
           expect(team2).to match_array [bp3, bp4, bp5, bp7]
+        end
+
+        it "persists the results" do
+          subject
+
+          expect(battle.reload.elo_diff).to eq 9
+          expect(bp1.reload.team_balance).to eq 1
+          expect(bp2.reload.team_balance).to eq 1
+          expect(bp3.reload.team_balance).to eq 2
+          expect(bp4.reload.team_balance).to eq 2
+          expect(bp5.reload.team_balance).to eq 2
+          expect(bp6.reload.team_balance).to eq 1
+          expect(bp7.reload.team_balance).to eq 2
+          expect(bp8.reload.team_balance).to eq 1
         end
       end
     end


### PR DESCRIPTION
Added `elo_diff` as an integer column on `Battles`
* Absolute value

Added `team_balance` as an integer column on `BattlePlayer`.
* Represents the assigned team for the player in the most balanced configuration. Does not imply axis or allies side

Created `Ratings::BattleRatingsService` to handle battle balance logic
* `#find_most_balanced_teams` finds the elo difference and teams for the most balanced teams scenario. Persists elo_diff to Battle and team_balance to BattlePlayer
* `#clear_battle_balance_data` to clear Battle.elo_diff and BattlePlayer.team_balance

## Follow-on
1. BattlesService needs additional logic to call `Ratings::BattleRatingsService.new(battle).find_most_balanced_teams` when the battle is full.
2. BattlesService needs additional logic to call `Ratings::BattleRatingsService.new(battle).clear_battle_balance_data` when the battle is no longer full.
3. ONLY WHEN THE BATTLE IS FULL in the UI, show a component representing the two assigned sides for most balanced teams. Probably want to only show this for players in the battle to reduce clutter for other users. Could be a box of 2 columns of names in between the header row and the `BattleCardPlayer`s of the `BattleCard`. Since we are only showing this for players in the battle, we should be comfortable taking up more space in exchange for a more obvious and clear balance assignment result.