### PR TITLE
Introduce map vetoes and sync from CDN for better map management

### DIFF
--- a/app/api/omg/api.rb
+++ b/app/api/omg/api.rb
@@ -41,6 +41,7 @@ module OMG
     mount Leaderboard
     mount Rulesets
     mount Stats
+    mount MapVetoes
 
     route :any, '*path' do
       error! "Not implemented", 404

--- a/app/api/omg/map_vetoes.rb
+++ b/app/api/omg/map_vetoes.rb
@@ -1,0 +1,61 @@
+module OMG
+  class MapVetoes < Grape::API
+    resource :maps do
+      desc "Get all enabled maps"
+      get do
+        present Map.enabled.order(:category, :name), using: Map::Entity
+      end
+    end
+
+    resource :map_vetoes do
+      before do
+        authenticate!
+      end
+
+      desc "Get vetoes for a company"
+      params do
+        requires :companyId, type: Integer, desc: "Company id"
+      end
+      get do
+        company = Company.find(declared_params[:companyId])
+        error!("Not your company", 403) unless company.player_id == current_player.id
+
+        present company.vetoed_maps, using: Map::Entity
+      end
+
+      desc "Add a map veto for a company"
+      params do
+        requires :companyId, type: Integer, desc: "Company id"
+        requires :mapId, type: Integer, desc: "Map id to veto"
+      end
+      post do
+        company = Company.find(declared_params[:companyId])
+        error!("Not your company", 403) unless company.player_id == current_player.id
+
+        map = Map.find(declared_params[:mapId])
+        veto = MapVeto.new(company: company, map: map)
+
+        if veto.save
+          present company.vetoed_maps.reload, using: Map::Entity
+        else
+          error!(veto.errors.full_messages.join(", "), 422)
+        end
+      end
+
+      desc "Remove a map veto for a company"
+      params do
+        requires :companyId, type: Integer, desc: "Company id"
+        requires :mapId, type: Integer, desc: "Map id to remove veto for"
+      end
+      delete do
+        company = Company.find(declared_params[:companyId])
+        error!("Not your company", 403) unless company.player_id == current_player.id
+
+        veto = company.map_vetoes.find_by!(map_id: declared_params[:mapId])
+        veto.destroy!
+
+        present company.vetoed_maps.reload, using: Map::Entity
+      end
+    end
+  end
+end

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,4 @@
 //= link_tree ../images
 //= link_tree ../builds
 //= link application.css
+//= link admin.css

--- a/app/controllers/admin/maps_controller.rb
+++ b/app/controllers/admin/maps_controller.rb
@@ -1,0 +1,36 @@
+module Admin
+  class MapsController < AdminController
+    before_action :set_map, only: [:update]
+
+    def index
+      @maps = Map.order(:category, :name)
+      @competitive_maps = @maps.competitive
+      @meme_maps = @maps.meme
+    end
+
+    def update
+      if @map.update(map_params)
+        redirect_to admin_maps_path, notice: "Map was successfully updated."
+      else
+        redirect_to admin_maps_path, alert: @map.errors.full_messages.to_sentence
+      end
+    end
+
+    def sync
+      result = MapSyncService.new.sync
+      redirect_to admin_maps_path, notice: "Synced #{result[:total]} maps from CDN (#{result[:created]} new)."
+    rescue => e
+      redirect_to admin_maps_path, alert: "Failed to sync maps: #{e.message}"
+    end
+
+    private
+
+    def set_map
+      @map = Map.find(params[:id])
+    end
+
+    def map_params
+      params.require(:map).permit(:category, :enabled)
+    end
+  end
+end

--- a/app/javascript/app/store.js
+++ b/app/javascript/app/store.js
@@ -23,6 +23,7 @@ import rulesetsSlice from "../features/rulesets/rulesetsSlice";
 import statsUnitsSlice from "../features/stats/units/statsUnitsSlice";
 import statsEntitiesSlice from "../features/stats/entities/statsEntitiesSlice";
 import statsWeaponsSlice from "../features/stats/weapons/statsWeaponsSlice";
+import mapVetoSlice from "../features/companies/manage/map_vetoes/mapVetoSlice";
 
 export default configureStore({
   reducer: {
@@ -50,5 +51,6 @@ export default configureStore({
     statsUnits: statsUnitsSlice,
     statsEntities: statsEntitiesSlice,
     statsWeapons: statsWeaponsSlice,
+    mapVetoes: mapVetoSlice,
   },
 })

--- a/app/javascript/features/companies/manage/CompanyManager.jsx
+++ b/app/javascript/features/companies/manage/CompanyManager.jsx
@@ -24,7 +24,9 @@ import { CompactSelector } from "./CompactSelector";
 import { PageContainer } from "../../../components/PageContainer";
 import { SnapshotCreator } from "./SnapshotCreator";
 import HistoryIcon from "@mui/icons-material/History";
+import MapIcon from "@mui/icons-material/Map";
 import { CompanyWarLog } from "./CompanyWarLog";
+import { MapVetoes } from "./map_vetoes/MapVetoes";
 
 const useStyles = makeStyles(theme => ({
   headerRow: {
@@ -91,6 +93,7 @@ const SQUADS = "squads"
 const UNLOCKS = "unlocks"
 const BONUSES = "bonuses"
 const WAR_LOG = "war_log"
+const MAP_VETOES = "map_vetoes"
 const getCurrentUrlTab = (pathname) => {
   const lastPathElement = pathname.split("/").pop()
   switch (lastPathElement) {
@@ -100,6 +103,8 @@ const getCurrentUrlTab = (pathname) => {
       return BONUSES
     case WAR_LOG:
       return WAR_LOG
+    case MAP_VETOES:
+      return MAP_VETOES
     default:
       return SQUADS
   }
@@ -206,12 +211,20 @@ export const CompanyManager = () => {
                to={WAR_LOG}
                className={classes.tab}
                component={Link}/>
+          <Tab key={`company-manager-tab-${MAP_VETOES}`}
+               icon={matches ? <MapIcon/> : null}
+               label={matches ? null : "Map Vetoes"}
+               value={MAP_VETOES}
+               to={MAP_VETOES}
+               className={classes.tab}
+               component={Link}/>
         </Tabs>
         <Routes>
           <Route path="squads" element={<SquadBuilder/>}/>
           <Route path="unlocks" element={<CompanyUnlocks/>}/>
           <Route path="bonuses" element={<CompanyBonuses/>}/>
           <Route path={WAR_LOG} element={<CompanyWarLog/>}/>
+          <Route path={MAP_VETOES} element={<MapVetoes/>}/>
           <Route index element={<SquadBuilder/>}/>
         </Routes>
       </Box>

--- a/app/javascript/features/companies/manage/map_vetoes/MapVetoes.jsx
+++ b/app/javascript/features/companies/manage/map_vetoes/MapVetoes.jsx
@@ -1,0 +1,143 @@
+import React, { useEffect } from "react"
+import { useDispatch, useSelector } from "react-redux"
+import { useParams } from "react-router-dom"
+import { Box, Chip, CircularProgress, Typography } from "@mui/material"
+import BlockIcon from "@mui/icons-material/Block"
+
+import {
+  fetchMaps,
+  fetchCompanyVetoes,
+  addVeto,
+  removeVeto,
+  selectMaps,
+  selectCompanyVetoes,
+  selectLoadingMaps,
+  selectLoadingVetoes,
+} from "./mapVetoSlice"
+
+const MapCard = ({ map, isVetoed, onToggle, disabled }) => {
+  return (
+    <Chip
+      icon={isVetoed ? <BlockIcon /> : null}
+      label={map.name}
+      onClick={onToggle}
+      color={isVetoed ? "error" : "default"}
+      variant={isVetoed ? "filled" : "outlined"}
+      disabled={disabled}
+      sx={{ m: 0.5, fontSize: "0.85rem" }}
+    />
+  )
+}
+
+export const MapVetoes = () => {
+  const dispatch = useDispatch()
+  const { companyId } = useParams()
+
+  const maps = useSelector(selectMaps)
+  const companyVetoes = useSelector(selectCompanyVetoes)
+  const loadingMaps = useSelector(selectLoadingMaps)
+  const loadingVetoes = useSelector(selectLoadingVetoes)
+
+  useEffect(() => {
+    dispatch(fetchMaps())
+    dispatch(fetchCompanyVetoes({ companyId }))
+  }, [companyId])
+
+  const vetoedMapIds = companyVetoes.map((m) => m.id)
+  const competitiveMaps = maps.filter((m) => m.category === "competitive")
+  const memeMaps = maps.filter((m) => m.category === "meme")
+  const competitiveVetoId = companyVetoes.find(
+    (m) => m.category === "competitive"
+  )?.id
+
+  const handleToggle = (map) => {
+    const isVetoed = vetoedMapIds.includes(map.id)
+
+    if (isVetoed) {
+      dispatch(removeVeto({ companyId, mapId: map.id }))
+    } else {
+      if (map.category === "competitive" && competitiveVetoId) {
+        // Remove existing competitive veto first, then add new one
+        dispatch(removeVeto({ companyId, mapId: competitiveVetoId })).then(
+          () => {
+            dispatch(addVeto({ companyId, mapId: map.id }))
+          }
+        )
+      } else {
+        dispatch(addVeto({ companyId, mapId: map.id }))
+      }
+    }
+  }
+
+  if (loadingMaps || loadingVetoes) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", p: 4 }}>
+        <CircularProgress />
+      </Box>
+    )
+  }
+
+  if (maps.length === 0) {
+    return (
+      <Box sx={{ p: 2 }}>
+        <Typography color="text.secondary">
+          No maps available. An admin needs to sync maps from the CDN.
+        </Typography>
+      </Box>
+    )
+  }
+
+  return (
+    <Box sx={{ p: 2, width: "100%" }}>
+      <Typography variant="h6" gutterBottom>
+        Map Vetoes
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Veto maps you don't want to play. You can veto one competitive map and
+        any number of meme maps.
+      </Typography>
+
+      <Typography variant="subtitle1" sx={{ mt: 2, mb: 1, fontWeight: "bold" }}>
+        Competitive Maps
+        <Typography component="span" variant="body2" color="text.secondary" sx={{ ml: 1 }}>
+          (1 veto max)
+        </Typography>
+      </Typography>
+      <Box sx={{ display: "flex", flexWrap: "wrap" }}>
+        {competitiveMaps.map((map) => (
+          <MapCard
+            key={map.id}
+            map={map}
+            isVetoed={vetoedMapIds.includes(map.id)}
+            onToggle={() => handleToggle(map)}
+            disabled={false}
+          />
+        ))}
+        {competitiveMaps.length === 0 && (
+          <Typography color="text.secondary" variant="body2">No competitive maps configured.</Typography>
+        )}
+      </Box>
+
+      <Typography variant="subtitle1" sx={{ mt: 3, mb: 1, fontWeight: "bold" }}>
+        Meme Maps
+        <Typography component="span" variant="body2" color="text.secondary" sx={{ ml: 1 }}>
+          (unlimited vetoes)
+        </Typography>
+      </Typography>
+      <Box sx={{ display: "flex", flexWrap: "wrap" }}>
+        {memeMaps.map((map) => (
+          <MapCard
+            key={map.id}
+            map={map}
+            isVetoed={vetoedMapIds.includes(map.id)}
+            onToggle={() => handleToggle(map)}
+            disabled={false}
+          />
+        ))}
+        {memeMaps.length === 0 && (
+          <Typography color="text.secondary" variant="body2">No meme maps configured.</Typography>
+        )}
+      </Box>
+    </Box>
+  )
+}

--- a/app/javascript/features/companies/manage/map_vetoes/mapVetoSlice.js
+++ b/app/javascript/features/companies/manage/map_vetoes/mapVetoSlice.js
@@ -1,0 +1,111 @@
+import { createAsyncThunk, createSlice } from "@reduxjs/toolkit"
+import axios from "axios"
+
+const initialState = {
+  maps: [],
+  companyVetoes: [],
+  loadingMaps: false,
+  loadingVetoes: false,
+  error: null
+}
+
+export const fetchMaps = createAsyncThunk(
+  "mapVetoes/fetchMaps",
+  async (_, { rejectWithValue }) => {
+    try {
+      const response = await axios.get("/maps")
+      return response.data
+    } catch (err) {
+      return rejectWithValue(err.response.data)
+    }
+  }
+)
+
+export const fetchCompanyVetoes = createAsyncThunk(
+  "mapVetoes/fetchCompanyVetoes",
+  async ({ companyId }, { rejectWithValue }) => {
+    try {
+      const response = await axios.get("/map_vetoes", { params: { companyId } })
+      return response.data
+    } catch (err) {
+      return rejectWithValue(err.response.data)
+    }
+  }
+)
+
+export const addVeto = createAsyncThunk(
+  "mapVetoes/addVeto",
+  async ({ companyId, mapId }, { rejectWithValue }) => {
+    try {
+      const response = await axios.post("/map_vetoes", { companyId, mapId })
+      return response.data
+    } catch (err) {
+      return rejectWithValue(err.response.data)
+    }
+  }
+)
+
+export const removeVeto = createAsyncThunk(
+  "mapVetoes/removeVeto",
+  async ({ companyId, mapId }, { rejectWithValue }) => {
+    try {
+      const response = await axios.delete("/map_vetoes", { data: { companyId, mapId } })
+      return response.data
+    } catch (err) {
+      return rejectWithValue(err.response.data)
+    }
+  }
+)
+
+const mapVetoSlice = createSlice({
+  name: "mapVetoes",
+  initialState,
+  reducers: {},
+  extraReducers(builder) {
+    builder
+      .addCase(fetchMaps.pending, (state) => {
+        state.loadingMaps = true
+        state.error = null
+      })
+      .addCase(fetchMaps.fulfilled, (state, action) => {
+        state.loadingMaps = false
+        state.maps = action.payload
+      })
+      .addCase(fetchMaps.rejected, (state, action) => {
+        state.loadingMaps = false
+        state.error = action.payload
+      })
+      .addCase(fetchCompanyVetoes.pending, (state) => {
+        state.loadingVetoes = true
+        state.error = null
+      })
+      .addCase(fetchCompanyVetoes.fulfilled, (state, action) => {
+        state.loadingVetoes = false
+        state.companyVetoes = action.payload
+      })
+      .addCase(fetchCompanyVetoes.rejected, (state, action) => {
+        state.loadingVetoes = false
+        state.error = action.payload
+      })
+      .addCase(addVeto.fulfilled, (state, action) => {
+        state.companyVetoes = action.payload
+      })
+      .addCase(addVeto.rejected, (state, action) => {
+        state.error = action.payload
+      })
+      .addCase(removeVeto.fulfilled, (state, action) => {
+        state.companyVetoes = action.payload
+      })
+      .addCase(removeVeto.rejected, (state, action) => {
+        state.error = action.payload
+      })
+  }
+})
+
+export const selectMaps = (state) => state.mapVetoes.maps
+export const selectCompanyVetoes = (state) => state.mapVetoes.companyVetoes
+export const selectLoadingMaps = (state) => state.mapVetoes.loadingMaps
+export const selectLoadingVetoes = (state) => state.mapVetoes.loadingVetoes
+export const selectMapVetoError = (state) => state.mapVetoes.error
+
+export default mapVetoSlice.reducer

--- a/app/javascript/features/lobby/display/BattleCard.jsx
+++ b/app/javascript/features/lobby/display/BattleCard.jsx
@@ -233,6 +233,12 @@ export const BattleCard = ({ id }) => {
         </Box>
       </Box>
       {/*{fullBanner}*/}
+      {battle.map && (
+        <Box sx={{ display: "flex", alignItems: "center", pb: 1 }}>
+          <Typography variant="body1" color="text.secondary" sx={{ mr: 0.5 }}>Map:</Typography>
+          <Typography variant="body1" fontWeight="bold">{battle.map}</Typography>
+        </Box>
+      )}
       {generatingContent}
       {ingameContent}
       <Box className={classes.row}>

--- a/app/models/battle.rb
+++ b/app/models/battle.rb
@@ -5,6 +5,7 @@
 #  id                                                                   :bigint           not null, primary key
 #  elo_diff(Elo difference between most balanced teams, absolute value) :integer
 #  last_notified(Last time a notification was sent to players)          :datetime
+#  map(Map name)                                                        :string
 #  name(Optional battle name)                                           :string
 #  size(Size of each team)                                              :integer          not null
 #  state(Battle status)                                                 :string           not null

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -59,6 +59,8 @@ class Company < ApplicationRecord
   has_many :callin_modifiers, -> { distinct }, through: :company_callin_modifiers
   has_many :upgrades, -> { distinct }, through: :available_upgrades
   has_many :company_resource_bonuses, dependent: :destroy
+  has_many :map_vetoes, dependent: :destroy
+  has_many :vetoed_maps, through: :map_vetoes, source: :map
   has_many :battle_players, dependent: nil # Don't change the battle player
   has_many :transporting_transported_squads, through: :squads
   has_one :company_stats, dependent: :destroy

--- a/app/models/faction.rb
+++ b/app/models/faction.rb
@@ -5,8 +5,9 @@
 #  id                                                           :bigint           not null, primary key
 #  const_name(Faction CONST name for battlefile)                :string           not null
 #  display_name(Display name)                                   :string           not null
-#  internal_name(Name for internal code use, may not be needed) :string
+#  internal_name(Name for internal code use, may not be needed) :string           not null
 #  name(Raw name)                                               :string           not null
+#  race(In-game race id)                                        :integer
 #  side(Allied or Axis side)                                    :string           not null
 #  created_at                                                   :datetime         not null
 #  updated_at                                                   :datetime         not null

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -1,0 +1,34 @@
+# == Schema Information
+#
+# Table name: maps
+#
+#  id                                               :bigint           not null, primary key
+#  category(Map category: meme or competitive)      :string           default("competitive"), not null
+#  enabled(Whether this map is in the rotation)     :boolean          default(TRUE), not null
+#  name(Map name from CDN manifest (e.g. 4p_Arras)) :string           not null
+#  created_at                                       :datetime         not null
+#  updated_at                                       :datetime         not null
+#
+# Indexes
+#
+#  index_maps_on_category  (category)
+#  index_maps_on_enabled   (enabled)
+#  index_maps_on_name      (name) UNIQUE
+#
+class Map < ApplicationRecord
+  enum category: { meme: "meme", competitive: "competitive" }
+
+  has_many :map_vetoes, dependent: :destroy
+
+  validates :name, presence: true, uniqueness: true
+  validates :category, presence: true
+
+  scope :enabled, -> { where(enabled: true) }
+
+  class Entity < Grape::Entity
+    expose :id
+    expose :name
+    expose :category
+    expose :enabled
+  end
+end

--- a/app/models/map_veto.rb
+++ b/app/models/map_veto.rb
@@ -1,0 +1,22 @@
+class MapVeto < ApplicationRecord
+  self.table_name = "map_vetoes"
+
+  belongs_to :company
+  belongs_to :map
+
+  validates :map_id, uniqueness: { scope: :company_id }
+  validate :competitive_veto_limit
+
+  private
+
+  def competitive_veto_limit
+    return unless map&.competitive?
+
+    existing = MapVeto.joins(:map)
+                      .where(company_id: company_id)
+                      .where(maps: { category: "competitive" })
+                      .where.not(id: id)
+
+    errors.add(:base, "Company can only veto one competitive map") if existing.exists?
+  end
+end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -8,7 +8,7 @@
 #  current_sign_in_ip                                 :string
 #  last_sign_in_at                                    :datetime
 #  last_sign_in_ip                                    :string
-#  name(Player screen name)                           :string
+#  name(Player screen name)                           :string           not null
 #  provider(Omniauth provider)                        :string
 #  remember_created_at                                :datetime
 #  role(Player role for permissions)                  :string           not null

--- a/app/models/upgrades/ability.rb
+++ b/app/models/upgrades/ability.rb
@@ -6,6 +6,7 @@
 #  additional_model_count(How many model entities this upgrade adds to the base unit) :integer
 #  const_name(Upgrade const name used by the battlefile)                              :string
 #  description(Upgrade description)                                                   :string
+#  disabled(override that disables the upgrade from being purchased or used)          :boolean          default(FALSE), not null
 #  display_name(Display upgrade name)                                                 :string           not null
 #  model_count(How many model entities this unit replacement consists of)             :integer
 #  name(Unique upgrade name)                                                          :string           not null

--- a/app/models/upgrades/building.rb
+++ b/app/models/upgrades/building.rb
@@ -6,6 +6,7 @@
 #  additional_model_count(How many model entities this upgrade adds to the base unit) :integer
 #  const_name(Upgrade const name used by the battlefile)                              :string
 #  description(Upgrade description)                                                   :string
+#  disabled(override that disables the upgrade from being purchased or used)          :boolean          default(FALSE), not null
 #  display_name(Display upgrade name)                                                 :string           not null
 #  model_count(How many model entities this unit replacement consists of)             :integer
 #  name(Unique upgrade name)                                                          :string           not null

--- a/app/models/upgrades/consumable.rb
+++ b/app/models/upgrades/consumable.rb
@@ -6,6 +6,7 @@
 #  additional_model_count(How many model entities this upgrade adds to the base unit) :integer
 #  const_name(Upgrade const name used by the battlefile)                              :string
 #  description(Upgrade description)                                                   :string
+#  disabled(override that disables the upgrade from being purchased or used)          :boolean          default(FALSE), not null
 #  display_name(Display upgrade name)                                                 :string           not null
 #  model_count(How many model entities this unit replacement consists of)             :integer
 #  name(Unique upgrade name)                                                          :string           not null

--- a/app/models/upgrades/passive.rb
+++ b/app/models/upgrades/passive.rb
@@ -6,6 +6,7 @@
 #  additional_model_count(How many model entities this upgrade adds to the base unit) :integer
 #  const_name(Upgrade const name used by the battlefile)                              :string
 #  description(Upgrade description)                                                   :string
+#  disabled(override that disables the upgrade from being purchased or used)          :boolean          default(FALSE), not null
 #  display_name(Display upgrade name)                                                 :string           not null
 #  model_count(How many model entities this unit replacement consists of)             :integer
 #  name(Unique upgrade name)                                                          :string           not null

--- a/app/models/upgrades/single_weapon.rb
+++ b/app/models/upgrades/single_weapon.rb
@@ -6,6 +6,7 @@
 #  additional_model_count(How many model entities this upgrade adds to the base unit) :integer
 #  const_name(Upgrade const name used by the battlefile)                              :string
 #  description(Upgrade description)                                                   :string
+#  disabled(override that disables the upgrade from being purchased or used)          :boolean          default(FALSE), not null
 #  display_name(Display upgrade name)                                                 :string           not null
 #  model_count(How many model entities this unit replacement consists of)             :integer
 #  name(Unique upgrade name)                                                          :string           not null

--- a/app/models/upgrades/squad_weapon.rb
+++ b/app/models/upgrades/squad_weapon.rb
@@ -6,6 +6,7 @@
 #  additional_model_count(How many model entities this upgrade adds to the base unit) :integer
 #  const_name(Upgrade const name used by the battlefile)                              :string
 #  description(Upgrade description)                                                   :string
+#  disabled(override that disables the upgrade from being purchased or used)          :boolean          default(FALSE), not null
 #  display_name(Display upgrade name)                                                 :string           not null
 #  model_count(How many model entities this unit replacement consists of)             :integer
 #  name(Unique upgrade name)                                                          :string           not null

--- a/app/models/upgrades/unit_replacement.rb
+++ b/app/models/upgrades/unit_replacement.rb
@@ -6,6 +6,7 @@
 #  additional_model_count(How many model entities this upgrade adds to the base unit) :integer
 #  const_name(Upgrade const name used by the battlefile)                              :string
 #  description(Upgrade description)                                                   :string
+#  disabled(override that disables the upgrade from being purchased or used)          :boolean          default(FALSE), not null
 #  display_name(Display upgrade name)                                                 :string           not null
 #  model_count(How many model entities this unit replacement consists of)             :integer
 #  name(Unique upgrade name)                                                          :string           not null

--- a/app/services/battle_service.rb
+++ b/app/services/battle_service.rb
@@ -128,6 +128,7 @@ class BattleService
       # If the battle has all players ready, move to generating state
       if battle.reload.all_players_ready?
         battle.ready!
+        MapSelectionService.new(battle).select_map
         type = PLAYERS_ALL_READY
       else
         type = PLAYER_READY

--- a/app/services/map_selection_service.rb
+++ b/app/services/map_selection_service.rb
@@ -1,0 +1,19 @@
+class MapSelectionService
+  def initialize(battle)
+    @battle = battle
+  end
+
+  def select_map
+    return if Map.enabled.none?
+
+    company_ids = @battle.battle_players.pluck(:company_id)
+    vetoed_map_ids = MapVeto.where(company_id: company_ids).pluck(:map_id).uniq
+
+    eligible = Map.enabled.where.not(id: vetoed_map_ids)
+    eligible = Map.enabled if eligible.empty?
+
+    selected = eligible.order("RANDOM()").first
+    @battle.update!(map: selected.name)
+    selected
+  end
+end

--- a/app/services/map_sync_service.rb
+++ b/app/services/map_sync_service.rb
@@ -1,0 +1,47 @@
+require "http"
+require "rexml/document"
+
+class MapSyncService
+  MANIFEST_URL = "https://data.omgmod.net/versions/manifest.xml"
+  MAP_PATTERN = /^\d+p_/
+
+  def sync
+    xml = fetch_manifest
+    map_names = parse_map_names(xml)
+
+    created = 0
+    map_names.each do |name|
+      map = Map.find_or_initialize_by(name: name)
+      if map.new_record?
+        map.save!
+        created += 1
+      end
+    end
+
+    { total: map_names.size, created: created }
+  end
+
+  private
+
+  def fetch_manifest
+    response = HTTP.get(MANIFEST_URL)
+    raise "Failed to fetch manifest: #{response.status}" unless response.status.success?
+
+    response.body.to_s
+  end
+
+  def parse_map_names(xml)
+    doc = REXML::Document.new(xml)
+    names = []
+
+    doc.elements.each("//directory[@name='Archives']/file") do |file|
+      filename = file.attributes["name"]
+      next unless filename&.match?(MAP_PATTERN)
+
+      name = filename.sub(/\.sga\z/i, "")
+      names << name
+    end
+
+    names.uniq
+  end
+end

--- a/app/views/admin/base/index.html.erb
+++ b/app/views/admin/base/index.html.erb
@@ -8,5 +8,8 @@
     <div class="col-4">
       <%= link_to "Players", admin_players_path, class: "btn btn-primary" %>
     </div>
+    <div class="col-4">
+      <%= link_to "Maps", admin_maps_path, class: "btn btn-primary" %>
+    </div>
   </div>
 </main>

--- a/app/views/admin/maps/index.html.erb
+++ b/app/views/admin/maps/index.html.erb
@@ -1,0 +1,92 @@
+<main class="container">
+  <div class="header row mb-3">
+    <div class="col">
+      <h1>Maps</h1>
+    </div>
+    <div class="col text-end">
+      <%= button_to "Sync from CDN", sync_admin_maps_path, method: :post, class: "btn btn-primary" %>
+    </div>
+  </div>
+
+  <h3>Competitive Maps</h3>
+  <% if @competitive_maps.any? %>
+    <table class="table table-dark table-striped">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Enabled</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @competitive_maps.each do |map| %>
+          <tr>
+            <td><%= map.name %></td>
+            <td>
+              <% if map.enabled? %>
+                <span class="badge bg-success">Enabled</span>
+              <% else %>
+                <span class="badge bg-secondary">Disabled</span>
+              <% end %>
+            </td>
+            <td>
+              <%= button_to map.enabled? ? "Disable" : "Enable",
+                    admin_map_path(map),
+                    params: { map: { enabled: !map.enabled? } },
+                    method: :patch,
+                    class: "btn btn-sm btn-outline-warning d-inline" %>
+              <%= button_to "Move to Meme",
+                    admin_map_path(map),
+                    params: { map: { category: "meme" } },
+                    method: :patch,
+                    class: "btn btn-sm btn-outline-info d-inline" %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <p class="text-muted">No competitive maps. Click "Sync from CDN" to import maps.</p>
+  <% end %>
+
+  <h3 class="mt-4">Meme Maps</h3>
+  <% if @meme_maps.any? %>
+    <table class="table table-dark table-striped">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Enabled</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @meme_maps.each do |map| %>
+          <tr>
+            <td><%= map.name %></td>
+            <td>
+              <% if map.enabled? %>
+                <span class="badge bg-success">Enabled</span>
+              <% else %>
+                <span class="badge bg-secondary">Disabled</span>
+              <% end %>
+            </td>
+            <td>
+              <%= button_to map.enabled? ? "Disable" : "Enable",
+                    admin_map_path(map),
+                    params: { map: { enabled: !map.enabled? } },
+                    method: :patch,
+                    class: "btn btn-sm btn-outline-warning d-inline" %>
+              <%= button_to "Move to Competitive",
+                    admin_map_path(map),
+                    params: { map: { category: "competitive" } },
+                    method: :patch,
+                    class: "btn btn-sm btn-outline-info d-inline" %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <p class="text-muted">No meme maps.</p>
+  <% end %>
+</main>

--- a/config/database.yml
+++ b/config/database.yml
@@ -12,7 +12,7 @@ default: &default
 
 development:
   <<: *default
-  host: 192.168.1.142
+  host: localhost
   database: omg_development
   username: <%= ENV.fetch('POSTGRES_USER', "mma")  %>
   password: <%= ENV.fetch('POSTGRES_PASSWORD', "password") %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -12,7 +12,7 @@ default: &default
 
 development:
   <<: *default
-  host: localhost
+  host: 192.168.1.142
   database: omg_development
   username: <%= ENV.fetch('POSTGRES_USER', "mma")  %>
   password: <%= ENV.fetch('POSTGRES_PASSWORD', "password") %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,12 @@ Rails.application.routes.draw do
 
           resources :players
 
+          resources :maps, only: [:index, :update] do
+            collection do
+              post :sync
+            end
+          end
+
           root to: "base#index"
         end
       end

--- a/db/migrate/20260404200000_create_maps.rb
+++ b/db/migrate/20260404200000_create_maps.rb
@@ -1,0 +1,15 @@
+class CreateMaps < ActiveRecord::Migration[7.0]
+  def change
+    create_table :maps do |t|
+      t.string :name, null: false, comment: "Map name from CDN manifest (e.g. 4p_Arras)"
+      t.string :category, null: false, default: "competitive", comment: "Map category: meme or competitive"
+      t.boolean :enabled, null: false, default: true, comment: "Whether this map is in the rotation"
+
+      t.timestamps
+    end
+
+    add_index :maps, :name, unique: true
+    add_index :maps, :category
+    add_index :maps, :enabled
+  end
+end

--- a/db/migrate/20260404200001_create_map_vetoes.rb
+++ b/db/migrate/20260404200001_create_map_vetoes.rb
@@ -1,0 +1,12 @@
+class CreateMapVetoes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :map_vetoes do |t|
+      t.references :company, null: false, foreign_key: true
+      t.references :map, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :map_vetoes, [:company_id, :map_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_04_11_224053) do
+ActiveRecord::Schema[7.0].define(version: 2026_04_04_200001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -354,6 +354,27 @@ ActiveRecord::Schema[7.0].define(version: 2025_04_11_224053) do
     t.datetime "updated_at", null: false
     t.index ["player_id"], name: "index_historical_player_ratings_on_player_id"
     t.index ["player_name"], name: "index_historical_player_ratings_on_player_name", unique: true
+  end
+
+  create_table "map_vetoes", force: :cascade do |t|
+    t.bigint "company_id", null: false
+    t.bigint "map_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["company_id", "map_id"], name: "index_map_vetoes_on_company_id_and_map_id", unique: true
+    t.index ["company_id"], name: "index_map_vetoes_on_company_id"
+    t.index ["map_id"], name: "index_map_vetoes_on_map_id"
+  end
+
+  create_table "maps", force: :cascade do |t|
+    t.string "name", null: false, comment: "Map name from CDN manifest (e.g. 4p_Arras)"
+    t.string "category", default: "competitive", null: false, comment: "Map category: meme or competitive"
+    t.boolean "enabled", default: true, null: false, comment: "Whether this map is in the rotation"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category"], name: "index_maps_on_category"
+    t.index ["enabled"], name: "index_maps_on_enabled"
+    t.index ["name"], name: "index_maps_on_name", unique: true
   end
 
   create_table "offmaps", force: :cascade do |t|
@@ -828,6 +849,8 @@ ActiveRecord::Schema[7.0].define(version: 2025_04_11_224053) do
   add_foreign_key "doctrine_unlocks", "unlocks"
   add_foreign_key "doctrines", "factions"
   add_foreign_key "historical_battle_players", "rulesets"
+  add_foreign_key "map_vetoes", "companies"
+  add_foreign_key "map_vetoes", "maps"
   add_foreign_key "offmaps", "rulesets"
   add_foreign_key "player_ratings", "players"
   add_foreign_key "resource_bonuses", "rulesets"

--- a/spec/models/faction_spec.rb
+++ b/spec/models/faction_spec.rb
@@ -5,8 +5,9 @@
 #  id                                                           :bigint           not null, primary key
 #  const_name(Faction CONST name for battlefile)                :string           not null
 #  display_name(Display name)                                   :string           not null
-#  internal_name(Name for internal code use, may not be needed) :string
+#  internal_name(Name for internal code use, may not be needed) :string           not null
 #  name(Raw name)                                               :string           not null
+#  race(In-game race id)                                        :integer
 #  side(Allied or Axis side)                                    :string           not null
 #  created_at                                                   :datetime         not null
 #  updated_at                                                   :datetime         not null

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -8,7 +8,7 @@
 #  current_sign_in_ip                                 :string
 #  last_sign_in_at                                    :datetime
 #  last_sign_in_ip                                    :string
-#  name(Player screen name)                           :string
+#  name(Player screen name)                           :string           not null
 #  provider(Omniauth provider)                        :string
 #  remember_created_at                                :datetime
 #  role(Player role for permissions)                  :string           not null

--- a/spec/models/squad_spec.rb
+++ b/spec/models/squad_spec.rb
@@ -5,6 +5,7 @@
 #  id                                                                :bigint           not null, primary key
 #  category_position(Position within the tab the squad is in)        :integer          not null
 #  name(Squad's custom name)                                         :string
+#  pop(Total pop of the squad including unit and all upgrades)       :decimal(, )
 #  tab_category(Tab this squad is in)                                :string           not null
 #  total_model_count(Total model count of the unit and all upgrades) :integer
 #  uuid(Unique uuid)                                                 :string           not null

--- a/spec/models/upgrades/ability_spec.rb
+++ b/spec/models/upgrades/ability_spec.rb
@@ -6,6 +6,7 @@
 #  additional_model_count(How many model entities this upgrade adds to the base unit) :integer
 #  const_name(Upgrade const name used by the battlefile)                              :string
 #  description(Upgrade description)                                                   :string
+#  disabled(override that disables the upgrade from being purchased or used)          :boolean          default(FALSE), not null
 #  display_name(Display upgrade name)                                                 :string           not null
 #  model_count(How many model entities this unit replacement consists of)             :integer
 #  name(Unique upgrade name)                                                          :string           not null

--- a/spec/models/upgrades/building_spec.rb
+++ b/spec/models/upgrades/building_spec.rb
@@ -6,6 +6,7 @@
 #  additional_model_count(How many model entities this upgrade adds to the base unit) :integer
 #  const_name(Upgrade const name used by the battlefile)                              :string
 #  description(Upgrade description)                                                   :string
+#  disabled(override that disables the upgrade from being purchased or used)          :boolean          default(FALSE), not null
 #  display_name(Display upgrade name)                                                 :string           not null
 #  model_count(How many model entities this unit replacement consists of)             :integer
 #  name(Unique upgrade name)                                                          :string           not null

--- a/spec/models/upgrades/consumable_spec.rb
+++ b/spec/models/upgrades/consumable_spec.rb
@@ -6,6 +6,7 @@
 #  additional_model_count(How many model entities this upgrade adds to the base unit) :integer
 #  const_name(Upgrade const name used by the battlefile)                              :string
 #  description(Upgrade description)                                                   :string
+#  disabled(override that disables the upgrade from being purchased or used)          :boolean          default(FALSE), not null
 #  display_name(Display upgrade name)                                                 :string           not null
 #  model_count(How many model entities this unit replacement consists of)             :integer
 #  name(Unique upgrade name)                                                          :string           not null

--- a/spec/models/upgrades/passive_spec.rb
+++ b/spec/models/upgrades/passive_spec.rb
@@ -6,6 +6,7 @@
 #  additional_model_count(How many model entities this upgrade adds to the base unit) :integer
 #  const_name(Upgrade const name used by the battlefile)                              :string
 #  description(Upgrade description)                                                   :string
+#  disabled(override that disables the upgrade from being purchased or used)          :boolean          default(FALSE), not null
 #  display_name(Display upgrade name)                                                 :string           not null
 #  model_count(How many model entities this unit replacement consists of)             :integer
 #  name(Unique upgrade name)                                                          :string           not null

--- a/spec/models/upgrades/single_weapon_spec.rb
+++ b/spec/models/upgrades/single_weapon_spec.rb
@@ -6,6 +6,7 @@
 #  additional_model_count(How many model entities this upgrade adds to the base unit) :integer
 #  const_name(Upgrade const name used by the battlefile)                              :string
 #  description(Upgrade description)                                                   :string
+#  disabled(override that disables the upgrade from being purchased or used)          :boolean          default(FALSE), not null
 #  display_name(Display upgrade name)                                                 :string           not null
 #  model_count(How many model entities this unit replacement consists of)             :integer
 #  name(Unique upgrade name)                                                          :string           not null

--- a/spec/models/upgrades/squad_weapon_spec.rb
+++ b/spec/models/upgrades/squad_weapon_spec.rb
@@ -6,6 +6,7 @@
 #  additional_model_count(How many model entities this upgrade adds to the base unit) :integer
 #  const_name(Upgrade const name used by the battlefile)                              :string
 #  description(Upgrade description)                                                   :string
+#  disabled(override that disables the upgrade from being purchased or used)          :boolean          default(FALSE), not null
 #  display_name(Display upgrade name)                                                 :string           not null
 #  model_count(How many model entities this unit replacement consists of)             :integer
 #  name(Unique upgrade name)                                                          :string           not null

--- a/spec/models/upgrades/unit_replacement_spec.rb
+++ b/spec/models/upgrades/unit_replacement_spec.rb
@@ -6,6 +6,7 @@
 #  additional_model_count(How many model entities this upgrade adds to the base unit) :integer
 #  const_name(Upgrade const name used by the battlefile)                              :string
 #  description(Upgrade description)                                                   :string
+#  disabled(override that disables the upgrade from being purchased or used)          :boolean          default(FALSE), not null
 #  display_name(Display upgrade name)                                                 :string           not null
 #  model_count(How many model entities this unit replacement consists of)             :integer
 #  name(Unique upgrade name)                                                          :string           not null


### PR DESCRIPTION
### Summary
This pull request introduces a system for map vetoes and enables syncing maps from a CDN to improve map management.

### Changes
- Added functionality to veto specific maps.
- Implemented syncing of maps from a CDN.
- Improved overall map handling and management processes.

### Checklist
- [ ] Ensure all new features are properly tested.
- [ ] Update documentation to include information about vetoes and CDN syncing.
- [ ] Confirm the changes meet expected performance criteria. 

